### PR TITLE
Removing incorrect error comment

### DIFF
--- a/manuscript/02-Functions.md
+++ b/manuscript/02-Functions.md
@@ -112,7 +112,7 @@ You can bind the value of `this` to `PageHandler` explicitly using the `bind()` 
 
         init: function() {
             document.addEventListener("click", (function(event) {
-                this.doSomething(event.type);     // error
+                this.doSomething(event.type);
             }).bind(this), false);
         },
 


### PR DESCRIPTION
In the first refactoring step for the "PageHandler" example the "// error" comment is not correct anymore, right?
