### PR TITLE
Add closing ^ on exponents

### DIFF
--- a/manuscript/01-The-Basics.md
+++ b/manuscript/01-The-Basics.md
@@ -1027,7 +1027,7 @@ In this code, `Number.isInteger()` returns `true` for both `25` and `25.0` even 
 
 #### Safe Integers
 
-However, all is not so simple with integers. JavaScript can only accurately represent integers between -2^53 and 2^53, and outside of this "safe" range, binary representations end up reused for multiple numeric values. For example:
+However, all is not so simple with integers. JavaScript can only accurately represent integers between -2^53^ and 2^53^, and outside of this "safe" range, binary representations end up reused for multiple numeric values. For example:
 
 ```js
 console.log(Math.pow(2, 53));      // 9007199254740992


### PR DESCRIPTION
The second caret is being interpreted as closing the first one:
![screen shot 2014-11-29 at 3 42 39 pm](https://cloud.githubusercontent.com/assets/952293/5235773/cca7a1de-77df-11e4-8291-6d02284b2459.png)
