### PR TITLE
Fix undefined function in example

### DIFF
--- a/manuscript/02-Functions.md
+++ b/manuscript/02-Functions.md
@@ -298,7 +298,6 @@ var doAnotherThing = function() {
 };
 
 console.log(doSomething.name);          // "doSomething"
-console.log(doSomethingElse.name);      // "doSomethingElse"
 console.log(doAnotherThing.name);       // "doAnotherThing"
 ```
 


### PR DESCRIPTION
The name of the function is being logged, but the function is not defined in the example.
