### PR TITLE
Made multiple grammatical changes

### DIFF
--- a/manuscript/01-The-Basics.md
+++ b/manuscript/01-The-Basics.md
@@ -431,7 +431,7 @@ console.log(re.source);     // "ab"
 console.log(re.flags);      // "g"
 ```
 
-Using `source` and `flags` together allow you to extra just the pieces of the regular expression that are necessary without needing to parse the regular expression string directly.
+Using `source` and `flags` together allow you to extract just the pieces of the regular expression that are necessary without needing to parse the regular expression string directly.
 
 
 ## Object.is()
@@ -942,7 +942,7 @@ function getValue() {
 
 By making these two changes, ECMAScript 5 sought to eliminate a lot of the confusion and errors associated with octal literals.
 
-ECMAScript 6 took things a step further by reintroducing an octal literal notation, along with a binary literal notation. Both of these notations take a hint for the hexadecimal literal notation of prepending `0x`or `0X` to a value. The new octal literal format begins with `0o` or `0O` while the new binary literal format begins with `0b` or `0B`. Each literal type must be followed by one or more digits, 0-7 for octal, 0-1 for binary. Here's an example:
+ECMAScript 6 took things a step further by reintroducing an octal literal notation, along with a binary literal notation. Both of these notations take a hint for the hexadecimal literal notation of prepending `0x` or `0X` to a value. The new octal literal format begins with `0o` or `0O` while the new binary literal format begins with `0b` or `0B`. Each literal type must be followed by one or more digits, 0-7 for octal, 0-1 for binary. Here's an example:
 
 ```js
 // ECMAScript 6
@@ -975,7 +975,7 @@ JavaScript has long had a couple of global methods for identifying certain types
 * `isFinite()` determines if a value represents a finite number (not `Infinity` or `-Infinity`)
 * `isNaN()` determines if a value is `NaN` (since `NaN` is the only value that is not equal to itself)
 
-Although intended to work with numbers, these methods are capable of inferring a numeric value from and value that is passed in. That both methods can return incorrect results when passed a value that isn't a number. For example:
+Although intended to work with numbers, these methods are capable of inferring a numeric value from any value that is passed in. That means both methods can return incorrect results when passed a value that isn't a number. For example:
 
 ```js
 console.log(isFinite(25));      // true

--- a/manuscript/02-Functions.md
+++ b/manuscript/02-Functions.md
@@ -48,7 +48,7 @@ makeRequest("/foo", 500, function(body) {
 });
 ```
 
-Any parameters with a default value are considered to be optional parameters while those without default value are considered to be required parameters.
+Any parameters with a default value are considered to be optional parameters while those without a default value are considered to be required parameters.
 
 It's possible to specify default values for any arguments, including those that appear before arguments without default values. For example, this is fine:
 
@@ -186,7 +186,7 @@ setCookie("type", "js", {
 });
 ```
 
-There are many `setCookie()` functions in JavaScript libraries that look similar to this. The `name` and `value` are required but everything else is not. And since there is no priority order for the other data, it makes sense to have an options object with named properties rather than extra named properties. This approach is okay, although it makes the expect input for the function a bit opaque.
+There are many `setCookie()` functions in JavaScript libraries that look similar to this. The `name` and `value` are required but everything else is not. And since there is no priority order for the other data, it makes sense to have an options object with named properties rather than extra named parameters. This approach is okay, although it makes the expected input for the function a bit opaque.
 
 Using destructured parameters, the previous function can be rewritten as follows:
 
@@ -239,7 +239,7 @@ I> It's recommended to always provide the default value for destructured paramet
 
 ## The Spread Operator
 
-Closely related to rest parameters is the spread operator. Whereas rest parameters allow you to specify multiple independent arguments should be combined into an array, the spread operator allows you to specify an array that should be be split and have its items passed in as separate arguments to a function. Consider the `Math.max()` method, which accepts any number of arguments and returns the one with the highest value. It's basic usage is as follows:
+Closely related to rest parameters is the spread operator. Whereas rest parameters allow you to specify that multiple independent arguments should be combined into an array, the spread operator allows you to specify an array that should be be split and have its items passed in as separate arguments to a function. Consider the `Math.max()` method, which accepts any number of arguments and returns the one with the highest value. It's basic usage is as follows:
 
 ```js
 let value1 = 25,
@@ -427,11 +427,11 @@ In this example, `doSomething()` is hoisted into the global scope so that it sti
 One of the most interesting new parts of ECMAScript 6 are arrow functions. Arrow functions are, as the name suggests, functions defined with a new syntax that uses an "arrow" (`=>`). However, arrow functions behave differently than traditional JavaScript functions in a number of important ways:
 
 * **Lexical `this` binding** - The value of `this` inside of the function is determined by where the arrow function is defined not where it is used.
-* **Not `new`able** - Arrow functions cannot be used a constructors and will throw an error when used with `new`.
+* **Not `new`able** - Arrow functions cannot be used as constructors and will throw an error when used with `new`.
 * **Can't change `this`** - The value of `this` inside of the function can't be changed, it remains the same value throughout the entire lifecycle of the function.
 * **No `arguments` object** - You can't access arguments through the `arguments` object, you must use named arguments or other ES6 features such as rest arguments.
 
-There are a few reasons why these differences exist. First and foremost, `this` binding is a common source of error in JavaScript. It's very easy to lose track of the `this` value inside of a function and can easily result in unintended consequences. Second, by limiting arrow functions to simply executing code with a single `this` value, JavaScript engines can more easily optimize these operations (as opposed to regular functions, which might be used as a constructor or otherwise modified).
+There are a few reasons why these differences exist. First and foremost, `this` binding is a common source of error in JavaScript. It's very easy to lose track of the `this` value inside of a function, which can result in unintended consequences. Second, by limiting arrow functions to simply executing code with a single `this` value, JavaScript engines can more easily optimize these operations (as opposed to regular functions, which might be used as a constructor or otherwise modified).
 
 I> Arrow functions also have a `name` property that follows the same rule as other functions.
 

--- a/manuscript/06-Iterators-And-Generators.md
+++ b/manuscript/06-Iterators-And-Generators.md
@@ -73,8 +73,6 @@ W> The `for-of` statement will throw an error when used on a `null` or `undefine
 
 You might be thinking that iterators sound interesting but they look like a bunch of work. Indeed, writing iterators so that they adhere to the correct behavior is a bit difficult, which is why ECMAScript 6 provides generators. A *generator* is a special kind of function that returns an iterator. Generator functions are indicated by inserting a star character (`*`) after the `function` keyword (it doesn't matter if the star is directly next to `function` or if there's some whitespace between them). The `yield` keyword is used inside of generators to specify the values that the iterator should return when `next()` is called. So if you want to return three different values for each successive call to `next()`, you can do so as follows:
 
-For example:
-
 ```js
 // generator
 function *createIterator() {
@@ -498,7 +496,7 @@ function *createIterator() {
     } catch (ex) {
         second = 6;                     // on error, assign a different value
     }
-    yield second + 3;                   // never is executed
+    yield second + 3;                   
 }
 
 let iterator = createIterator();
@@ -513,7 +511,7 @@ In this example, a `try-catch` block is wrapped around the second `yield` statem
 
 You'll also notice something interesting happened - the `throw()` method returned a value similar to that returned by `next()`. Because the error was caught inside the generator, code execution continued on to the next `yield` and returned the appropriate value.
 
-It helps to think of `next()` and `throw()` as both being instructions to the iterator: `next()` instructs the iterator to continue to executing (possibly with a given value) and `throw()` instructs the iterator to continue executing by throwing an error. What happens after that point depends on the code inside the generator.
+It helps to think of `next()` and `throw()` as both being instructions to the iterator: `next()` instructs the iterator to continue executing (possibly with a given value) and `throw()` instructs the iterator to continue executing by throwing an error. What happens after that point depends on the code inside the generator.
 
 ### Generator Return Statements
 

--- a/manuscript/08-Symbols.md
+++ b/manuscript/08-Symbols.md
@@ -129,13 +129,13 @@ var uid3 = Symbol("uid");
 console.log(Symbol.keyFor(uid3));   // undefined
 ```
 
-Notice that both `uid` and `uid2` return the key `"uid"`. The symbol `uid3` doesn't exist in the global symbol registry, so it has no key associated with it and so `Symbol.keyFor()` returns `undefined`.
+Notice that both `uid` and `uid2` return the key `"uid"`. The symbol `uid3` doesn't exist in the global symbol registry, so it has no key associated with it and `Symbol.keyFor()` returns `undefined`.
 
 W> The global symbol registry is a shared environment, just like the global scope. That means you can't make assumptions about what is or is not already present in that environment. You should use namespacing of symbol keys to reduce the likelihood of naming collisions when using third-party components. For example, jQuery might prefix all keys with `"jquery."`, such as `"jquery.element"`.
 
 ## Finding Object Symbols
 
-As with other properties on objects, you can access symbol properties using the `Object.getOwnPropertySymbols()` method. This method works exactly the same as `Object.getOwnPropertyNames()` except that the returned values are symbols rather than strings. Since symbols technically aren't property names, they are omitted from the result of `Object.getOwnPropertyNames()`.
+Similar to other properties on objects, you can access symbol properties using the `Object.getOwnPropertySymbols()` method. This method works exactly the same as `Object.getOwnPropertyNames()` except that the returned values are symbols rather than strings. Since symbols technically aren't property names, they are omitted from the result of `Object.getOwnPropertyNames()`.
 
 The return value of `Object.getOwnPropertySymbols()` is an array of symbols that represent own properties. For example:
 
@@ -261,7 +261,7 @@ Only applied to `with` statement object records - does not refer to other scopes
 
 ### @@iterator
 
-As you learned in chapter 6, iterators are an important part of ECMAScript 6, and many built-in types has default iterators defined. These default iterators are defined by the `@@iterator` symbol on their prototype. The `for-of` loop uses an object's `@@iterator` property to retrieve an iterator when the given value isn't already one. You can get a reference to the default iterator for arrays using `Symbol.iterator`, such as:
+As you learned in chapter 6, iterators are an important part of ECMAScript 6, and many built-in types have default iterators defined. These default iterators are defined by the `@@iterator` symbol on their prototype. The `for-of` loop uses an object's `@@iterator` property to retrieve an iterator when the given value isn't already one. You can get a reference to the default iterator for arrays using `Symbol.iterator`, such as:
 
 ```js
 // retrieve the default generator for arrays


### PR DESCRIPTION
Changed wording in multiple areas to clarify meaning, correct grammar, or resolve typos. In addition, removed one comment from a sample code block which was not relevant (it was leftover from a previous sample).
