### PR TITLE
improve readability (take 2)

### DIFF
--- a/chap00.html
+++ b/chap00.html
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en">
 <head>
 <title>Introduction</title>
+<meta charset="utf-8">
 <link href="stylesheet.css" type="text/css" rel="stylesheet" />
 </head>
 <body>

--- a/chap01.html
+++ b/chap01.html
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en">
 <head>
 <title>The Basics</title>
+<meta charset="utf-8">
 <link href="stylesheet.css" type="text/css" rel="stylesheet" />
 </head>
 <body>
@@ -316,7 +315,7 @@
     <code class="p">}</code>
 <code class="p">}</code>
 </pre></div>
-  
+
 </div>
 
     </td>
@@ -876,7 +875,7 @@
      <code class="nx">func</code><code class="p">();</code>     <code class="c1">// outputs the number "10" ten times</code>
  <code class="p">});</code>
 </pre></div>
-  
+
 </div>
 
   <p>This code will output the number <code>10</code> ten times in a row. That’s because the variable <code>i</code> is shared across each iteration of the loop, meaning the closures created inside the loop all hold a reference to the same variable. The variable <code>i</code> has a value of <code>10</code> once the loop completes, and so that’s the value each function outputs.</p>
@@ -898,7 +897,7 @@
      <code class="nx">func</code><code class="p">();</code>     <code class="c1">// outputs 0, then 1, then 2, up to 9</code>
  <code class="p">});</code>
 </pre></div>
-  
+
 </div>
 
   <p>This version of the example uses an IIFE inside of the loop. The <code>i</code> variable is passed to the IIFE, which creates its own copy and stores it as <code>value</code>. This is the value used of the function for that iteration, so calling each function returns the expected value.</p>
@@ -916,7 +915,7 @@
      <code class="nx">func</code><code class="p">();</code>     <code class="c1">// outputs 0, then 1, then 2, up to 9</code>
  <code class="p">})</code>
 </pre></div>
-  
+
 </div>
 
   <p>This code works exactly like the code that used <code>var</code> and an IIFE but is, arguably, cleaner.</p>
@@ -997,7 +996,7 @@
 <div class="highlight"><pre> <code class="kd">let</code> <code class="nb">RegExp</code> <code class="o">=</code> <code class="s2">"Hello!"</code><code class="p">;</code>          <code class="c1">// ok</code>
  <code class="kd">let</code> <code class="kc">undefined</code> <code class="o">=</code> <code class="s2">"Hello!"</code><code class="p">;</code>       <code class="c1">// throws error</code>
 </pre></div>
-  
+
 </div>
 
   <p>The first line of this example redefines the global <code>RegExp</code> as a string. Even though this would be problematic, there is no error thrown. The second line throws an error because <code>undefined</code> is a nonconfigurable own property of the global object. Since it’s definition is locked down by the environment, the <code>let</code> declaration is illegal.</p>
@@ -1196,7 +1195,7 @@
 <div class="highlight"><pre><code class="c1">// syntax error</code>
 <code class="p">{</code> <code class="nx">repeat</code><code class="p">,</code> <code class="nx">save</code><code class="p">,</code> <code class="nx">rules</code><code class="o">:</code> <code class="p">{</code> <code class="nx">custom</code> <code class="p">}}</code> <code class="o">=</code> <code class="nx">options</code><code class="p">;</code>
 </pre></div>
-  
+
 </div>
 
   <p>This causes a syntax error because the opening curly brace is normally the beginning of a block and blocks can’t be part of assignment expressions.</p>
@@ -1207,7 +1206,7 @@
 <div class="highlight"><pre><code class="c1">// no syntax error</code>
 <code class="p">({</code> <code class="nx">repeat</code><code class="p">,</code> <code class="nx">save</code><code class="p">,</code> <code class="nx">rules</code><code class="o">:</code> <code class="p">{</code> <code class="nx">custom</code> <code class="p">}})</code> <code class="o">=</code> <code class="nx">options</code><code class="p">;</code>
 </pre></div>
-  
+
 </div>
 
   <p>This now works without any problems.</p>

--- a/chap02.html
+++ b/chap02.html
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en">
 <head>
 <title>Functions</title>
+<meta charset="utf-8">
 <link href="stylesheet.css" type="text/css" rel="stylesheet" />
 </head>
 <body>

--- a/chap03.html
+++ b/chap03.html
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en">
 <head>
 <title>Objects</title>
+<meta charset="utf-8">
 <link href="stylesheet.css" type="text/css" rel="stylesheet" />
 </head>
 <body>
@@ -461,7 +460,7 @@
 <code class="nx">console</code><code class="p">.</code><code class="nx">log</code><code class="p">(</code><code class="nx">descriptor</code><code class="p">.</code><code class="nx">value</code><code class="p">);</code>      <code class="c1">// "file.js"</code>
 <code class="nx">console</code><code class="p">.</code><code class="nx">log</code><code class="p">(</code><code class="nx">descriptor</code><code class="p">.</code><code class="nx">get</code><code class="p">);</code>        <code class="c1">// undefined</code>
 </pre></div>
-  
+
 </div>
 
   <p>In this code, the <code>supplier</code> has an accessor property called <code>name</code>. After using <code>Object.assign()</code>, <code>receiver.name</code> exists as a data property with the value of <code>"file.js"</code>. That’s because <code>supplier.name</code> returned “file.js” at the time <code>Object.assign()</code> was called.</p>

--- a/chap04.html
+++ b/chap04.html
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en">
 <head>
 <title>Symbols</title>
+<meta charset="utf-8">
 <link href="stylesheet.css" type="text/css" rel="stylesheet" />
 </head>
 <body>

--- a/chap05.html
+++ b/chap05.html
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en">
 <head>
 <title>Iterators and Generators</title>
+<meta charset="utf-8">
 <link href="stylesheet.css" type="text/css" rel="stylesheet" />
 </head>
 <body>

--- a/chap06.html
+++ b/chap06.html
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en">
 <head>
 <title>Template Strings</title>
+<meta charset="utf-8">
 <link href="stylesheet.css" type="text/css" rel="stylesheet" />
 </head>
 <body>
@@ -313,7 +312,7 @@
                                 <code class="c1">//  string"</code>
 <code class="n">console</code><code class="p">.</code><code class="n">log</code><code class="p">(</code><code class="n">message</code><code class="p">.</code><code class="n">length</code><code class="p">);</code>    <code class="c1">// 16</code>
 </pre></div>
-  
+
 </div>
 
 </div>

--- a/index.html
+++ b/index.html
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en">
 <head>
 <title>Table of Contents</title>
+<meta charset="utf-8">
 <link href="stylesheet.css" type="text/css" rel="stylesheet" />
 </head>
 <body>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,18 +1,29 @@
+body {
+  font-family: Georgia, serif;
+  color: #222;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  direction: ltr;
+}
+
 div#leanpub-toc {
   width: 300px;
   float: left;
+  line-height: 1.5;
+  margin-left: 2em;
 }
 
 div#leanpub-main {
   width: 700px;
   float: left;
+  margin-left: 2em;
 }
 
-// Book ToC
-// ----------------------
-
+/* Book ToC */
 .toc {
   list-style: none;
+  padding: 0;
 }
 .toc li {
   list-style: none;
@@ -64,23 +75,23 @@ h1, h2, h3, h4, h5, h6, h7 {
 }
 
 /* Parts */
-h1 { 
+h1 {
    font-size: 4em;
    line-height: .8em;
    font-variant: small-caps;
-   margin-top: 20%; 
+   margin-top: 20%;
    text-align: center;
    padding: 0;
    font-weight: normal;
 }
 
 /* Chapters */
-h2 { 
+h2 {
    margin-bottom: 1em;
 }
 
 /* Sections */
-h3 { 
+h3 {
    margin-top: 1em;
    margin-bottom: 0.25em;
 }
@@ -93,15 +104,16 @@ h5 { margin-top: 1em;
    margin-bottom: 0.25em;
  }
 
-h6 { 
+h6 {
    margin: 0;
  }
 
 /* general text */
 
-p { 
-  text-indent: 0em; 
+p {
+  text-indent: 0em;
   margin-top: 0.5em;
+  line-height: 1.5;
 }
 
 .hanging-indent p {
@@ -127,7 +139,7 @@ div.sidebarish h1, div.sidebarish h2, div.sidebarish h3, div.sidebarish h4 {
   vertical-align: center;
 }
 
-div.sidebarish   { 
+div.sidebarish   {
   margin: 50px 0px 50px 10px;
   padding-left: 60px;
 }
@@ -149,10 +161,6 @@ pre {
    margin-top: 0.5em;
    margin-bottom: 0.5em;
    font-family: Courier, monospace;
-}
-
-body {
-  direction: ltr;
 }
 
 /* image equations */


### PR DESCRIPTION
- don't break code blocks
- use utf-8 everywhere

This is what it looks like:

![bildschirmfoto 2015-01-27 um 11 40 57](https://cloud.githubusercontent.com/assets/778624/5917115/8be0fa2a-a619-11e4-9291-db22dfa37302.png)

I had to explicitly set `utf-8` because firefox wasn't happy.