### PR TITLE
fix typo in Symbols:@@toStringTag chapter

### DIFF
--- a/manuscript/04-Symbols.md
+++ b/manuscript/04-Symbols.md
@@ -188,7 +188,7 @@ Some of the well-known symbols are discussed below while others are discussed th
 
 ### @@toStringTag
 
-Once of the most interesting problems in JavaScript has been the availability of multiple global execution environments. This occurs in web browsers when a page includes an iframe, as the page and the iframe each have their own execution environments. In most cases, this isn't a problem, as data can be passed back and forth between the environments with little cause for concern. The problem arises when trying to identify what type of an object you're dealing with.
+One of the most interesting problems in JavaScript has been the availability of multiple global execution environments. This occurs in web browsers when a page includes an iframe, as the page and the iframe each have their own execution environments. In most cases, this isn't a problem, as data can be passed back and forth between the environments with little cause for concern. The problem arises when trying to identify what type of an object you're dealing with.
 
 The canonical example of this is passing an array from the iframe into the containing page or vice-versa. Now in a different execution environment, `instanceof Array` returns `false` because the array was created with a constructor from a different environment.
 


### PR DESCRIPTION
BTW I found the wording of the following sentence confusing:

> The Symbol.for() method accepts a single parameter, which is a string identifier for the symbol you want to create **(this value doubles as the description)**

maybe it could be somehow reworded? (I'm not opening a separate issue for that, up to you to handle it)

Regards,
Jakub