### PR TITLE
Fixed var declarations in reg exp example

### DIFF
--- a/manuscript/01-The-Basics.md
+++ b/manuscript/01-The-Basics.md
@@ -344,7 +344,7 @@ The sticky flag saves the index of the next character after the last match in `l
 ```js
 var text = "hello1 hello2 hello3",
     pattern = /hello\d\s?/,
-    result = pattern.exec(text);
+    result = pattern.exec(text),
     globalPattern = /hello\d\s?/g,
     globalResult = globalPattern.exec(text),
     stickyPattern = /hello\d\s?/y,

--- a/manuscript/01-The-Basics.md
+++ b/manuscript/01-The-Basics.md
@@ -314,7 +314,7 @@ ECMAScript 6 standardized the `y` flag after it had been implemented in Firefox 
 ```js
 var text = "hello1 hello2 hello3",
     pattern = /hello\d\s?/,
-    result = pattern.exec(text);
+    result = pattern.exec(text),
     globalPattern = /hello\d\s?/g,
     globalResult = globalPattern.exec(text),
     stickyPattern = /hello\d\s?/y,


### PR DESCRIPTION
Fixed typo in var declarations in reg exp example