### PR TITLE
Clarify syntax in Ch. 8 - Iterators and Generators 

### DIFF
--- a/manuscript/08-Iterators-And-Generators.md
+++ b/manuscript/08-Iterators-And-Generators.md
@@ -262,7 +262,7 @@ for (let x of collection) {
 // 3
 ```
 
-This code defines a default iterator for a variable called `collection` using object literal method shorthand and a computed property using `Symbol.iterator`. The generator then delegates to the `values()` iterator of `this.items`. The `for-of` loop then uses the generator to create an iterator and execute the loop.
+This code defines a default iterator for a variable called `collection` using object literal method shorthand and a computed property using `Symbol.iterator`. The generator then delegates to the `values()` iterator of `this.items` using the `yield *` notation, discussed later in this chapter. The `for-of` loop then uses the generator to create an iterator and execute the loop.
 
 You can also define a default iterator using classes, such as:
 

--- a/manuscript/08-Iterators-And-Generators.md
+++ b/manuscript/08-Iterators-And-Generators.md
@@ -41,7 +41,7 @@ console.log(iterator.next());           // "{ value: undefined, done: true }"
 console.log(iterator.next());           // "{ value: undefined, done: true }"
 ```
 
-The `createIterator()` function in this example returns an object with a `next()` method. Each time the method is called, the next value in the `items` array is returned as `value`. When `i` is 4, `items[i++]` returns `undefined` and `done` is `true`, which fulfills the special last case for iterators in ECMAScript 6.
+The `createIterator()` function in this example returns an object with a `next()` method. Each time the method is called, the next value in the `items` array is returned as `value`. When `i` is 3, `items[i++]` returns `undefined` and `done` is `true`, which fulfills the special last case for iterators in ECMAScript 6.
 
 ECMAScript 6 makes use of iterators in a number of places to make dealing with collections of data easier, so having a good basic understanding allows you to better understand the language as a whole.
 


### PR DESCRIPTION
Generator delegation is discussed later on, so this form of `yield` looks out of place here and might cause confusion. This edit follows an already existing pattern in the manuscript; there are 4 occurrences where concept clarification is explicitly deferred to later sections.