### PR TITLE
Fixed typo. (Functions/Rest parameters)

### DIFF
--- a/manuscript/02-Functions.md
+++ b/manuscript/02-Functions.md
@@ -126,7 +126,7 @@ console.log(bookData.year);     // 2015
 
 This function mimics the `pick()` method from Underscore. The first argument is the object from which to copy properties and every other argument is the name of a property that should be copied on the result. There are couple of things to notice about this function. First, it's not at all obvious that the function is capable of handling more than one parameter. You could add in several more named parameters, but you would always fall short of indicating that this function can take any number of parameters. Second, because the first parameter is named and used directly, you have to start looking in the `arguments` object at index 1 instead of starting at index 0. Remembering to use the appropriate indices with `arguments` isn't necessarily difficult, but it's one more thing to keep track of. ECMAScript 6 introduces rest parameters to help with these issues.
 
-Rest parameters are indicated by three dots (`...`) preceding a named parameter. That named parameter then becomes an `Array` containing the rest of the parameters (which is why these are called "rest" parameters). For example, `sum()` can be rewritten using rest parameters like this:
+Rest parameters are indicated by three dots (`...`) preceding a named parameter. That named parameter then becomes an `Array` containing the rest of the parameters (which is why these are called "rest" parameters). For example, `pick()` can be rewritten using rest parameters like this:
 
 ```js
 function pick(object, ...keys) {


### PR DESCRIPTION
Typo in the name of the example function.