### PR TITLE
Semicolon in object literal block removed

### DIFF
--- a/manuscript/01-Block-Bindings.md
+++ b/manuscript/01-Block-Bindings.md
@@ -172,7 +172,7 @@ A `const` declaration prevents modification of the binding and not of the value 
 
 ```js
 const person = {
-    name: "Nicholas";
+    name: "Nicholas"
 };
 
 // works


### PR DESCRIPTION
In node v4.2.1, that statement would not complete with that semicolon inside the object literal declaration-block.

Btw, this is indeed a subtle distinction you're explaining here. That's the reason I decided to take a look at it in node. I'm wondering  what console.log(person.name) equals before you attempt to change it to "Greg".

Well, it equals "Nicholas". So it is confusing when comparing "what an object is" with "what an object contains" (as you put it), because the dot notation seems to show "what an object is internally", when  "what an object contains (as you put it)" does not exist. I hope my description of my confusion here makes sense.