### PR TITLE
Fix a typo

### DIFF
--- a/manuscript/09-Classes.md
+++ b/manuscript/09-Classes.md
@@ -127,7 +127,7 @@ A>// but this is okay
 A> Foo = "baz";
 A> ```
 A>
-A> In this code, the `Foo` inside of the class constructor is a separate binding than the `Foo` outside of the class. The internal `Foo` is defined as if it's a `const` and so cannot be overwritten, which means and error is thrown when an attempt is made to do so; the external `Foo` is defined as if it's a `let` declaration and so its value may be overwritten at any time.
+A> In this code, the `Foo` inside of the class constructor is a separate binding than the `Foo` outside of the class. The internal `Foo` is defined as if it's a `const` and so cannot be overwritten, which means an error is thrown when an attempt is made to do so; the external `Foo` is defined as if it's a `let` declaration and so its value may be overwritten at any time.
 
 ## Class Expressions
 


### PR DESCRIPTION
Replace `and` with `an`