### PR TITLE
remove duplicate word

### DIFF
--- a/manuscript/08-Iterators-And-Generators.md
+++ b/manuscript/08-Iterators-And-Generators.md
@@ -856,7 +856,7 @@ run(function*() {
 });
 ```
 
-This example just outputs three numbers to the console, which simply shows that all calls to `next()` are being made. However, just yielding a couple times of times isn't very useful, so the next step is to pass values into and out of the iterator.
+This example just outputs three numbers to the console, which simply shows that all calls to `next()` are being made. However, just yielding a couple of times isn't very useful, so the next step is to pass values into and out of the iterator.
 
 ### Task Running With Data
 


### PR DESCRIPTION
Before:
> just yielding a couple times of times isn't very useful

After:
> just yielding a couple of times isn't very useful