### PR TITLE
Code samples format clean up.

### DIFF
--- a/manuscript/01-Block-Bindings.md
+++ b/manuscript/01-Block-Bindings.md
@@ -220,7 +220,7 @@ The TDZ is just one unique aspect of block bindings. Another unique aspect has t
 Perhaps one area where developers most want block level scoping of variables is within `for` loops, where the throwaway counter variable is meant to be used only inside the loop. For instance, it's not uncommon to see code like this in JavaScript:
 
 ```js
-for (var i=0; i < 10; i++) {
+for (var i = 0; i < 10; i++) {
     process(items[i]);
 }
 
@@ -231,7 +231,7 @@ console.log(i);                     // 10
 In other languages, where block level scoping is the default, this example should work as intended, and only the `for` loop should have access to the `i` variable. In JavaScript, however, the variable `i` is still accessible after the loop is completed because the `var` declaration gets hoisted. Using `let` instead, as in the following code, should give the intended behavior:
 
 ```js
-for (let i=0; i < 10; i++) {
+for (let i = 0; i < 10; i++) {
     process(items[i]);
 }
 
@@ -248,7 +248,7 @@ The characteristics of `var` have long made creating functions inside of loops p
 ```js
 var funcs = [];
 
-for (var i=0; i < 10; i++) {
+for (var i = 0; i < 10; i++) {
     funcs.push(function() { console.log(i); });
 }
 
@@ -264,7 +264,7 @@ To fix this problem, developers use immediately-invoked function expressions (II
 ```js
 var funcs = [];
 
-for (var i=0; i < 10; i++) {
+for (var i = 0; i < 10; i++) {
     funcs.push((function(value) {
         return function() {
             console.log(value);
@@ -286,7 +286,7 @@ A `let` declaration simplifies loops by effectively mimicking what the IIFE does
 ```js
 var funcs = [];
 
-for (let i=0; i < 10; i++) {
+for (let i = 0; i < 10; i++) {
     funcs.push(function() {
         console.log(i);
     });
@@ -330,7 +330,7 @@ The ECMAScript 6 specification doesn't explicitly disallow `const` declarations 
 var funcs = [];
 
 // throws an error after one iteration
-for (const i=0; i < 10; i++) {
+for (const i = 0; i < 10; i++) {
     funcs.push(function() {
         console.log(i);
     });

--- a/manuscript/08-Iterators-And-Generators.md
+++ b/manuscript/08-Iterators-And-Generators.md
@@ -93,7 +93,7 @@ The `yield` keyword can be used with any value or expression, so you can write g
 
 ```js
 function *createIterator(items) {
-    for (let i=0; i < items.length; i++) {
+    for (let i = 0; i < items.length; i++) {
         yield items[i];
     }
 }
@@ -119,7 +119,7 @@ You can use function expressions to create generators by just including a star (
 
 ```js
 let createIterator = function *(items) {
-    for (let i=0; i < items.length; i++) {
+    for (let i = 0; i < items.length; i++) {
         yield items[i];
     }
 };
@@ -147,7 +147,7 @@ Because generators are just functions, they can be added to objects, too. For ex
 var o = {
 
     createIterator: function *(items) {
-        for (let i=0; i < items.length; i++) {
+        for (let i = 0; i < items.length; i++) {
             yield items[i];
         }
     }
@@ -162,7 +162,7 @@ You can also use the ECMAScript 6 method shorthand by prepending the method name
 var o = {
 
     *createIterator(items) {
-        for (let i=0; i < items.length; i++) {
+        for (let i = 0; i < items.length; i++) {
             yield items[i];
         }
     }
@@ -477,7 +477,7 @@ JavaScript strings have slowly become more like arrays since ECMAScript 5 was re
 ```js
 var message = "A 𠮷 B";
 
-for (let i=0; i < message.length; i++) {
+for (let i = 0; i < message.length; i++) {
     console.log(message[i]);
 }
 ```
@@ -747,7 +747,7 @@ function *createNumberIterator() {
 }
 
 function *createRepeatingIterator(count) {
-    for (let i=0; i < count; i++) {
+    for (let i = 0; i < count; i++) {
         yield "repeat";
     }
 }
@@ -779,7 +779,7 @@ function *createNumberIterator() {
 }
 
 function *createRepeatingIterator(count) {
-    for (let i=0; i < count; i++) {
+    for (let i = 0; i < count; i++) {
         yield "repeat";
     }
 }


### PR DESCRIPTION
I saw that in some of the code samples, there are no spaces between the `=` and the identifier and the value in the loop init. section. Adding spaces to them for a better looking (also make it consistent with other loop blocks).