### PR TITLE
Check if sayName() wasn’t called with new in chapter 9

### DIFF
--- a/manuscript/09-Classes.md
+++ b/manuscript/09-Classes.md
@@ -215,6 +215,12 @@ let PersonClass = (function() {
 
     Object.defineProperty(PersonClass2.prototype, "sayName", {
         value: function() {
+
+            // make sure the method wasn't called with new
+            if (typeof new.target !== "undefined") {
+                throw new Error("Method cannot be called with new.");
+            }
+
             console.log(this.name);
         },
         enumerable: false,


### PR DESCRIPTION
In e37c23d781ccaae0ff15e1ae3a6368ab64611d85 `new.target` check was added to `sayName()` in *direct equivalent of PersonClass* example. Perhaps the same check should be in *direct equivalent of PersonClass named class expression* for consistency.