### PR TITLE
reject should short circuit

### DIFF
--- a/manuscript/11-Promises.md
+++ b/manuscript/11-Promises.md
@@ -215,6 +215,7 @@ function readFile(filename) {
             // check for errors
             if (err) {
                 reject(err);
+                return;
             }
 
             // the read succeeded


### PR DESCRIPTION
The code snippet for creating an unsettled promise does not short circuit and hence `resolve()` could still get called after an error is returned.  Even though this does not technically make a difference to the callback handler, the pattern may introduce side effects by running code that was meant to be run only when no errors were detected.