### PR TITLE
isNaN need to check value of the key, not the NaN.

### DIFF
--- a/manuscript/12-Proxies-and-Reflection.md
+++ b/manuscript/12-Proxies-and-Reflection.md
@@ -102,7 +102,7 @@ let proxy = new Proxy(target, {
 
         // ignore existing properties so as not to affect them
         if (!trapTarget.hasOwnProperty(key)) {
-            if (isNaN(NaN)) {
+            if (isNaN(value)) {
                 throw new TypeError("Property must be a number.");
             }
         }


### PR DESCRIPTION
In this example if statement needs to check the value, instead of NaN.