### PR TITLE
Forcing default param to be undefined

### DIFF
--- a/manuscript/03-Functions.md
+++ b/manuscript/03-Functions.md
@@ -259,8 +259,8 @@ function add(first = second, second) {
     return first + second;
 }
 
-console.log(add(1, 1));             // 2
-console.log(add(undefined, 1));     // throws error
+console.log(add(1, 1));         // 2
+console.log(add(undefined, 1)); // throws error
 ```
 
 The call to `add(undefined, 1)` throws an error because `second` is defined after `first` and is therefore unavailable as a default value. To understand why that happens, it's important to revisit temporal dead zones.

--- a/manuscript/03-Functions.md
+++ b/manuscript/03-Functions.md
@@ -263,7 +263,7 @@ console.log(add(1, 1));             // 2
 console.log(add(undefined, 1));     // throws error
 ```
 
-The call to `add(1)` throws an error because `second` is defined after `first` and is therefore unavailable as a default value. To understand why that happens, it's important to revisit temporal dead zones.
+The call to `add(undefined, 1)` throws an error because `second` is defined after `first` and is therefore unavailable as a default value. To understand why that happens, it's important to revisit temporal dead zones.
 
 ### Default Parameter Value Temporal Dead Zone
 

--- a/manuscript/03-Functions.md
+++ b/manuscript/03-Functions.md
@@ -260,7 +260,7 @@ function add(first = second, second) {
 }
 
 console.log(add(1, 1));     // 2
-console.log(add(1));        // throws error
+console.log(add(undefined, 1));        // throws error
 ```
 
 The call to `add(1)` throws an error because `second` is defined after `first` and is therefore unavailable as a default value. To understand why that happens, it's important to revisit temporal dead zones.

--- a/manuscript/03-Functions.md
+++ b/manuscript/03-Functions.md
@@ -259,8 +259,8 @@ function add(first = second, second) {
     return first + second;
 }
 
-console.log(add(1, 1));     // 2
-console.log(add(undefined, 1));        // throws error
+console.log(add(1, 1));             // 2
+console.log(add(undefined, 1));     // throws error
 ```
 
 The call to `add(1)` throws an error because `second` is defined after `first` and is therefore unavailable as a default value. To understand why that happens, it's important to revisit temporal dead zones.


### PR DESCRIPTION
The original version was adding 1 + undefined = NaN. Forcing first argument to be undefined to trigger ReferenceError. 
I noticed that the next section ('Default Parameter Value Temporal Dead Zone') has a correct explanation so instead of pulling this request you may remove the entire thing from the 'Default Parameter Expressions' section. 