### PR TITLE
Fix mistake in example with `Symbol.unscopables`.

### DIFF
--- a/manuscript/06-Symbols.md
+++ b/manuscript/06-Symbols.md
@@ -585,7 +585,7 @@ Array.prototype[Symbol.unscopables] = Object.assign(Object.create(null), {
     copyWithin: true,
     entries: true,
     fill: true,
-    find, true,
+    find: true,
     findIndex: true,
     keys: true,
     values: true


### PR DESCRIPTION
Seems like it's a mistake.