### PR TITLE
Add 'Appendix B' to title

### DIFF
--- a/manuscript/B-ECMAScript-7.md
+++ b/manuscript/B-ECMAScript-7.md
@@ -1,4 +1,4 @@
-# Understanding ECMAScript 7 (2016)
+# Appendix B: Understanding ECMAScript 7 (2016) 
 
 The development of ECMAScript 6 took about four years, and after that, TC-39 decided that such a long development process was unsustainable. Instead, they moved to a yearly release cycle to ensure new language features would make it into development sooner.
 


### PR DESCRIPTION
In Introduction we use use these titles for appendixes:

* **Appendix A: Smaller ECMAScript 6 Changes**
* **Appendix B: Understanding ECMAScript 7 (2016)**

but it the files we have different titles:

* **Appendix A: Smaller ECMAScript 6 Changes**
* **Understanding ECMAScript 7 (2016)**

This PR adds 'Appendix B' and eliminates this confusing moment.