### PR TITLE
FIX typo in chapter 4

### DIFF
--- a/manuscript/04-Objects.md
+++ b/manuscript/04-Objects.md
@@ -75,7 +75,7 @@ var person = {
 
 This shorthand syntax, also called *concise method* syntax, creates a method on the `person` object just as the previous example did. The `sayName()` property is assigned an anonymous function and has all the same characteristics as the ECMAScript 5 `sayName()` function. The one difference is that concise methods may use `super` (discussed later in the "Easy Prototype Access with Super References" section), while the nonconcise methods may not.
 
-I> The `name` property of a method created using concise method shorthand is the name used before the parentheses. In the last example, the `name` property for `person.sayName()` is `"sayName"`.
+I> The `name` property of a method created using concise method shorthand is the name used before the parentheses. In the last example, the `name` property for `person.sayName` is `"sayName"`.
 
 ### Computed Property Names
 


### PR DESCRIPTION
The result of person.sayName() is Nicholas. person.sayName().name === undefined,
but  person.sayName.name === "sayName", as expected

So, there should not be parentheses.

"In the last example, the name property for person.sayName is `"sayName"`." - like this.