### PR TITLE
fix(05-Destructing.md): minor fix to relocate the printout comment

### DIFF
--- a/manuscript/05-Destructuring.md
+++ b/manuscript/05-Destructuring.md
@@ -88,10 +88,10 @@ let node = {
     name = 5;
 
 function outputInfo(value) {
-    console.log(value === node);        // true
+    console.log(value === node);
 }
 
-outputInfo({ type, name } = node);
+outputInfo({ type, name } = node);        // true
 
 console.log(type);      // "Identifier"
 console.log(name);      // "foo"


### PR DESCRIPTION
Minor fix on `05-Destructing.md` to relocate the printout comment to the right place where it will be printed out when the code runs.