### PR TITLE
fix(09-Classes.md): replace [].values with Object.values([])

### DIFF
--- a/manuscript/09-Classes.md
+++ b/manuscript/09-Classes.md
@@ -420,7 +420,7 @@ class Collection {
     }
 
     *[Symbol.iterator]() {
-        yield *this.items.values();
+        yield *Object.values(this.items);
     }
 }
 


### PR DESCRIPTION
Change to the generally supported `Object.values` method, since `Array.prototype.values` is not yet supported on the latest Node.js; as of the writing of this.