### PR TITLE
fix IIFE function's typo

### DIFF
--- a/manuscript/01-Block-Bindings.md
+++ b/manuscript/01-Block-Bindings.md
@@ -269,7 +269,7 @@ for (var i = 0; i < 10; i++) {
         return function() {
             console.log(value);
         }
-    }(i)));
+    })(i));
 }
 
 funcs.forEach(function(func) {


### PR DESCRIPTION
Typo fix for the wrong position of the parenthesis.