### PR TITLE
Chapter 9: Keep constructor property non-enumerable

### DIFF
--- a/manuscript/09-Classes.md
+++ b/manuscript/09-Classes.md
@@ -514,8 +514,7 @@ function Square(length) {
 
 Square.prototype = Object.create(Rectangle.prototype, {
     constructor: {
-        value:Square,
-        enumerable: true,
+        value: Square,
         writable: true,
         configurable: true
     }


### PR DESCRIPTION
Before the Square.prototype object gets replaced, its initial constructor property is non-enumerable. Keeping the constructor property non-enumerable would conform better to expected behaviour (without adding any complexity to the code).