### PR TITLE
Update broken markdown style of the code block example layout confusion 

### DIFF
--- a/manuscript/04-Objects.md
+++ b/manuscript/04-Objects.md
@@ -240,27 +240,27 @@ The value of `receiver.type` is `"css"` because the second supplier overwrote th
 
 The `Object.assign()` method isn't a big addition to ECMAScript 6, but it does formalize a common function found in many JavaScript libraries.
 
-A> ### Working with Accessor Properties
-A>
-A> Keep in mind that `Object.assign()` doesn't create accessor properties on the receiver when a supplier has accessor properties. Since `Object.assign()` uses the assignment operator, an accessor property on a supplier will become a data property on the receiver. For example:
-A>
-A> ```js
-A> var receiver = {},
-A>     supplier = {
-A>         get name() {
-A>             return "file.js"
-A>         }
-A>     };
-A>
-A> Object.assign(receiver, supplier);
-A>
-A> var descriptor = Object.getOwnPropertyDescriptor(receiver, "name");
-A>
-A> console.log(descriptor.value);      // "file.js"
-A> console.log(descriptor.get);        // undefined
-A> ```
-A>
-A> In this code, the `supplier` has an accessor property called `name`. After using the `Object.assign()` method, `receiver.name` exists as a data property with a value of `"file.js"` because `supplier.name` returned `"file.js"` when `Object.assign()` was called.
+### Working with Accessor Properties
+
+Keep in mind that `Object.assign()` doesn't create accessor properties on the receiver when a supplier has accessor properties. Since `Object.assign()` uses the assignment operator, an accessor property on a supplier will become a data property on the receiver. For example:
+
+```js
+var receiver = {},
+    supplier = {
+        get name() {
+            return "file.js"
+        }
+    };
+
+Object.assign(receiver, supplier);
+
+var descriptor = Object.getOwnPropertyDescriptor(receiver, "name");
+
+console.log(descriptor.value);      // "file.js"
+console.log(descriptor.get);        // undefined
+```
+
+In this code, the `supplier` has an accessor property called `name`. After using the `Object.assign()` method, `receiver.name` exists as a data property with a value of `"file.js"` because `supplier.name` returned `"file.js"` when `Object.assign()` was called.
 
 ## Duplicate Object Literal Properties
 

--- a/manuscript/05-Destructuring.md
+++ b/manuscript/05-Destructuring.md
@@ -39,22 +39,22 @@ console.log(name);      // "foo"
 
 In this code, the value of `node.type` is stored in a variable called `type` and the value of `node.name` is stored in a variable called `name`. This syntax is the same as the object literal property initializer shorthand introduced in Chapter 4. The identifiers `type` and `name` are both declarations of local variables and the properties to read the value from on the `node` object.
 
-A> #### Don't Forget the Initializer
-A>
-A>When using destructuring to declare variables using `var`, `let`, or `const`, you must supply an initializer (the value after the equals sign). The following lines of code will all throw syntax errors due to a missing initializer:
-A>
-A>```js
-A>// syntax error!
-A>var { type, name };
-A>
-A>// syntax error!
-A>let { type, name };
-A>
-A>// syntax error!
-A>const { type, name };
-A>```
-A>
-A>While `const` always requires an initializer, even when using nondestructured variables, `var` and `let` only require initializers when using destructuring.
+#### Don't Forget the Initializer
+
+When using destructuring to declare variables using `var`, `let`, or `const`, you must supply an initializer (the value after the equals sign). The following lines of code will all throw syntax errors due to a missing initializer:
+
+```js
+// syntax error!
+var { type, name };
+
+// syntax error!
+let { type, name };
+
+// syntax error!
+const { type, name };
+```
+
+While `const` always requires an initializer, even when using nondestructured variables, `var` and `let` only require initializers when using destructuring.
 
 #### Destructuring Assignment
 
@@ -99,7 +99,7 @@ console.log(name);      // "foo"
 
 The `outputInfo()` function is called with a destructuring assignment expression. The expression evaluates to `node` because that is the value of the right side of the expression. The assignment to `type` and `name` both behave as normal and `node` is passed into `outputInfo()`.
 
-W> An error is thrown when the right side of the destructuring assignment expression (the expression after `=`) evaluates to `null` or `undefined`. This happens because any attempt to read a property of `null` or `undefined` results in a runtime error.
+An error is thrown when the right side of the destructuring assignment expression (the expression after `=`) evaluates to `null` or `undefined`. This happens because any attempt to read a property of `null` or `undefined` results in a runtime error.
 
 #### Default Values
 
@@ -229,16 +229,16 @@ In this version of the code, `node.loc.start` is stored in a new local variable 
 
 Object destructuring is very powerful and has a lot of options, but array destructuring offers some unique capabilities that allow you to extract information from arrays.
 
-A> #### Syntax Gotcha
-A>
-A>Be careful when using nested destructuring because you can inadvertently create a statement that has no effect. Empty curly braces are legal in object destructuring, however, they don't do anything. For example:
-A>
-A>```js
-A>// no variables declared!
-A>let { loc: {} } = node;
-A>```
-A>
-A>There are no bindings declared in this statement. Due to the curly braces on the right, `loc` is used as a location to inspect rather than a binding to create. In such a case, it's likely that the intent was to use `=` to define a default value rather than `:` to define a location. It's possible that this syntax will be made illegal in the future, but for now, this is a gotcha to look out for.
+#### Syntax Gotcha
+
+Be careful when using nested destructuring because you can inadvertently create a statement that has no effect. Empty curly braces are legal in object destructuring, however, they don't do anything. For example:
+
+```js
+// no variables declared!
+let { loc: {} } = node;
+```
+
+There are no bindings declared in this statement. Due to the curly braces on the right, `loc` is used as a location to inspect rather than a binding to create. In such a case, it's likely that the intent was to use `=` to define a default value rather than `:` to define a location. It's possible that this syntax will be made illegal in the future, but for now, this is a gotcha to look out for.
 
 ## Array Destructuring
 


### PR DESCRIPTION
Chapter 4:Update broken markdown style of the code block example layout confusion (243 lines to 263 lines)
Chapter 5:Update broken markdown style(42 lines to 57lines)