### PR TITLE
Fix 12-Proxies-and-Reflection.md chapter set trap

### DIFF
--- a/manuscript/12-Proxies-and-Reflection.md
+++ b/manuscript/12-Proxies-and-Reflection.md
@@ -103,7 +103,7 @@ let proxy = new Proxy(target, {
         // ignore existing properties so as not to affect them
         if (!trapTarget.hasOwnProperty(key)) {
             if (isNaN(value)) {
-                throw new TypeError("Property must be a number.");
+                throw new TypeError("Property value must be a number.");
             }
         }
 


### PR DESCRIPTION
I want to correct an error in 12-Proxies-and-Reflection.md  chapter：

Original：
```javascript
let proxy = new Proxy(target, {
    set(trapTarget, key, value, receiver) {

        // ignore existing properties so as not to affect them
        if (!trapTarget.hasOwnProperty(key)) {
            if (isNaN(value)) {
                throw new TypeError("Property must be a number.");
            }
        }

        // add the property
        return Reflect.set(trapTarget, key, value, receiver);
    }
});
```

Fix：`throw new TypeError ("Property must be a number.")` => `Throw new TypeError ("Property value must be a number.")`

```javascript
let proxy = new Proxy(target, {
    set(trapTarget, key, value, receiver) {

        // ignore existing properties so as not to affect them
        if (!trapTarget.hasOwnProperty(key)) {
            if (isNaN(value)) {
                throw new TypeError("Property value must be a number.");
            }
        }

        // add the property
        return Reflect.set(trapTarget, key, value, receiver);
    }
});
```