### PR TITLE
Typo in Chapter 13 Summary

### DIFF
--- a/manuscript/13-Modules.md
+++ b/manuscript/13-Modules.md
@@ -512,7 +512,7 @@ Each of these module specifiers cannot be loaded by the browser. The two module 
 
 ECMAScript 6 adds modules to the language as a way to package up and encapsulate functionality. Modules behave differently than scripts, as they don't modify the global scope with their top-level variables, functions, and classes, and `this` is `undefined`. To achieve that behavior, modules are loaded using a different mode.
 
-You must export any functionality you'd like to make available to consumers of a module. Variables, functions, and classes can all be exported, and there is also one default export allowed per module. After exporting, another module can import all or some of the exported names. These names act as if defined by `let` and operate as block bindings that can't be redeclared in the same module.
+You must export any functionality you'd like to make available to consumers of a module. Variables, functions, and classes can all be exported, and there is also one default export allowed per module. After exporting, another module can import all or some of the exported names. These names act as if defined by `const` and operate as block bindings that can't be redeclared in the same module.
 
 Modules need not export anything if they are manipulating something in the global scope. You can actually import from such a module without introducing any bindings into the module scope.
 


### PR DESCRIPTION
Based on Basic Importing section (Line 71), imported names from other modules act as if defined by `const` and in the summary it says `let` instead